### PR TITLE
Modificar  Acceso multiple fichero con sincro

### DIFF
--- a/Unidad 1/Proyectos_AccesosFicheroConSincro/AccesoMultipleFichero/src/accesomultiplefichero/Main.java
+++ b/Unidad 1/Proyectos_AccesosFicheroConSincro/AccesoMultipleFichero/src/accesomultiplefichero/Main.java
@@ -36,16 +36,16 @@ public class Main {
         if (args.length > 0) {
             orden = Integer.parseInt(args[0]);
             //Número de orden de creación de este proceso
-            try {
-                //Rediregimos salida y error estándar a un fichero
-                PrintStream ps = new PrintStream(
-                        new BufferedOutputStream(new FileOutputStream(
-                                new File("javalog.txt"), true)), true);
-                System.setOut(ps);
-                System.setErr(ps);
-            } catch (Exception e) {
-                System.err.println("P" + orden + " No he podido redirigir salidas.");
-            }
+        }
+        try {
+            //Rediregimos salida y error estándar a un fichero
+            PrintStream ps = new PrintStream(
+                    new BufferedOutputStream(new FileOutputStream(
+                            new File("javalog.txt"), true)), true);
+            System.setOut(ps);
+            System.setErr(ps);
+        } catch (Exception e) {
+            System.err.println("P" + orden + " No he podido redirigir salidas.");
         }
         //Identificamos el sistema operativo para poder acceder por su ruta al
         //fichero de forma correcta.


### PR DESCRIPTION
En el momento de redirigir la salida y error estándar al fichero, ésta sección de código se incluye dentro del "if" que comprueba si hemos introducido parámetros al ejecutar la clase, de modo que si se ejecuta sin parámetros, no hay escitura en el log.

Propongo esta modificación para que exista registro en el log independientemente del modo de ejecución de la clase.